### PR TITLE
ExportedNames incomplete for NameSpaceExport production

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -396,9 +396,9 @@ contributors: Lee Byron
         <emu-alg>
           1. Return the ExportedNames of |NamedExports|.
         </emu-alg>
-        <emu-grammar>ExportFromClause : NameSpaceExport</emu-grammar>
+        <emu-grammar>NameSpaceExport : `*` `as` IdentifierName </emu-grammar>
         <emu-alg>
-          1. Return the ExportedNames of |NameSpaceExport|.
+          1. Return a List containing the StringValue of |IdentifierName|.
         </emu-alg>
         </ins>
       </emu-clause>


### PR DESCRIPTION
Hi @jdalton, I'm pretty sure this is a necessary addition to the ExportedNames algorithm, can you review?

Presently, the [ExportedNames ](https://tc39.github.io/proposal-export-ns-from/#sec-exports-static-semantics-exportednames) has a rule for the production `NameSpaceExport` here:
```
ExportFromClause : NameSpaceExport
    Return the ExportedNames of NameSpaceExport. 
```
But no way to further evaluate the ExportedNames of NameSpaceExport.

I believe, because of the [chain of production](https://tc39.github.io/ecma262/#sec-algorithm-conventions-syntax-directed-operations) (and the line, `Return the ExportedNames of ExportFromClause` above), we can replace these lines with:
```
NameSpaceExport : * as IdentifierName
    Return a List containing the StringValue of IdentifierName.
```
